### PR TITLE
update to graceful-fs@^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "thenable"
   ],
   "dependencies": {
-    "graceful-fs": "^3.0.5",
+    "graceful-fs": "^4.0.0",
     "wrap-promise": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
> npm WARN deprecated graceful-fs@3.0.8: graceful-fs v3.0.0 and before will fail on node releases >= v6.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.
